### PR TITLE
ci, release: remove old Xcode use

### DIFF
--- a/tools/ci/release_cocoapods.sh
+++ b/tools/ci/release_cocoapods.sh
@@ -24,9 +24,4 @@ pod cache clean --all
 pod repo update --verbose
 
 publish_podspec "CaptureSwiftyBeaver"
-
-# Use Xcode 14.3.1 as Xcode 15 doesn't support iOS 11 and this is a minimal deployment target supported by Cocoalumberjack.
-# See https://github.com/CocoaPods/CocoaPods/issues/11839 for more details.
-# TODO(Augustyniak): Move to Xcode 15 once https://github.com/CocoaLumberjack/CocoaLumberjack/issues/1404 is resolved.
-sudo xcode-select --switch /Applications/Xcode_14.3.1.app
 publish_podspec "CaptureCocoaLumberjack"


### PR DESCRIPTION
This doesn't seem to be needed anymore.