### PR TITLE
Changed to use xcode 26.0.1

### DIFF
--- a/.github/workflows/release_cocoapods.yaml
+++ b/.github/workflows/release_cocoapods.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   release-cocoapods:
     name: Publish CocoaPods specs
-    runs-on: macos-26
+    runs-on: macos-15
     permissions:
       contents: read
     steps:
@@ -39,7 +39,7 @@ jobs:
 
   release-cocoapods-dep-specs:
     name: Publish integration CocoaPods specs
-    runs-on: macos-26
+    runs-on: macos-15
     permissions:
       contents: read
     needs: verify-cocoapods-release

--- a/.github/workflows/release_cocoapods.yaml
+++ b/.github/workflows/release_cocoapods.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   release-cocoapods:
     name: Publish CocoaPods specs
-    runs-on: macos-14
+    runs-on: macos-26
     permissions:
       contents: read
     steps:
@@ -39,7 +39,7 @@ jobs:
 
   release-cocoapods-dep-specs:
     name: Publish integration CocoaPods specs
-    runs-on: macos-14
+    runs-on: macos-26
     permissions:
       contents: read
     needs: verify-cocoapods-release
@@ -54,4 +54,3 @@ jobs:
           ./tools/ci/verify_release_cocoapods.sh CaptureCocoaLumberjack || pod trunk push CaptureCocoaLumberjack.podspec --verbose
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   tests:
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Set up CI

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up CI
         run: ./tools/ci/mac_ci_setup.sh
-      - name: Debug
-        run: xcrun simctl list runtimes && xcodebuild -version
       - name: Run Tests
         run: make test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,5 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up CI
         run: ./tools/ci/mac_ci_setup.sh
+      - name: Debug
+        run: xcrun simctl list runtimes && xcodebuild -version
       - name: Run Tests
         run: make test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,14 +6,14 @@ on:
   pull_request:
 # Cancel in-progress CI jobs when a new commit is pushed to a PR.
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   tests:
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Set up CI
         run: ./tools/ci/mac_ci_setup.sh
       - name: Run Tests
-        run:  make test
+        run: make test

--- a/.github/workflows/verify_cocoapods.yaml
+++ b/.github/workflows/verify_cocoapods.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   verify-cocoapods:
     name: verify
-    runs-on: macos-26
+    runs-on: macos-15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/verify_cocoapods.yaml
+++ b/.github/workflows/verify_cocoapods.yaml
@@ -1,13 +1,13 @@
 name: CocoaPods
 on:
-    push:
-      branches:
-        - main
-    pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   verify-cocoapods:
     name: verify
-    runs-on: macos-14
+    runs-on: macos-26
     permissions:
       contents: read
     steps:

--- a/tools/ci/mac_ci_setup.sh
+++ b/tools/ci/mac_ci_setup.sh
@@ -2,5 +2,5 @@
 
 set -euxo pipefail
 
-# https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
-sudo xcode-select --switch /Applications/Xcode_16.2.app
+# https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md#xcode
+sudo xcode-select --switch /Applications/Xcode_26.0.1.app

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -4,6 +4,6 @@ set -euxo pipefail
 
 xcodebuild \
   -scheme Capture-Package \
-  -sdk iphonesimulator18.2 \
-  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16' \
+  -sdk iphonesimulator26.0 \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17' \
   test

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -4,6 +4,6 @@ set -euxo pipefail
 
 xcodebuild \
   -scheme Capture-Package \
-  -sdk iphonesimulator26.0 \
+  -sdk iphonesimulator \
   -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17' \
   test

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -4,6 +4,6 @@ set -euxo pipefail
 
 xcodebuild \
   -scheme Capture-Package \
-  -sdk iphonesimulator \
+  -sdk iphonesimulator26.0 \
   -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17' \
   test


### PR DESCRIPTION
# Overview
This PR upgrades CI to use Xcode 26.0.1 across all workflows. As part of this, I needed to also update the `macos` runner to `macos-15`

> [!NOTE]
> **Why `macos-15` instead of `macos-26`?**
> The `macos-26` runner image ships with iOS simulator runtimes 26.1, 26.2, and 26.4 but not 26.0. Xcode 26.0.1's default SDK is `iphonesimulator26.0`, which causes both `xcodebuild` and `pod spec lint` to fail looking for a matching runtime. On the other hand, `macos-15` has Xcode 26.0.1 available and includes the iOS 26.0 simulator runtime, so everything works without any extra setup steps or runtime downloads.

