### PR TITLE
[BIT-9580] Include iOS related capture-sdk release notes into capture-ios

### DIFF
--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Generate release notes
+        id: release-notes
+        continue-on-error: true
         run: python3 tools/ci/generate_release_notes.py "$VERSION" release-notes.md
         env:
           GH_TOKEN: ${{ github.token }}
@@ -28,9 +30,19 @@ jobs:
       - name: Create GitHub Release
         id: create-gh-release
         run: |
-          gh release create "${{ inputs.version }}" \
-            --target "$GITHUB_REF_NAME" \
-            --title "${{ inputs.version }}" \
-            --notes-file release-notes.md
+          arguments=(
+            gh release create "$VERSION"
+            --target "$GITHUB_REF_NAME"
+            --title "$VERSION"
+          )
+
+          if [ -f release-notes.md ]; then
+            arguments+=(--notes-file release-notes.md)
+          else
+            echo "::warning title=Release notes unavailable::Publishing Capture iOS $VERSION without generated release notes."
+          fi
+
+          "${arguments[@]}"
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}

--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -20,11 +20,17 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - name: Generate release notes
+        run: python3 tools/ci/generate_release_notes.py "$VERSION" release-notes.md
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
       - name: Create GitHub Release
         id: create-gh-release
         run: |
           gh release create "${{ inputs.version }}" \
             --target "$GITHUB_REF_NAME" \
-            --title "${{ inputs.version }}"
+            --title "${{ inputs.version }}" \
+            --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tools/ci/generate_release_notes.py
+++ b/tools/ci/generate_release_notes.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+REPOSITORY = "bitdriftlabs/capture-sdk"
+CATEGORIES = ("Added", "Changed", "Fixed")
+CATEGORY_HEADER = re.compile(r"^\*\*\s*(Added|Changed|Fixed)\s*\*\*\s*$")
+
+
+def fetch_release_body(version: str) -> str:
+    """Gets the capture-sdk release notes for a specific version"""
+    tag = f"v{version.removeprefix('v')}"
+    url = f"https://api.github.com/repos/{REPOSITORY}/releases/tags/{urllib.parse.quote(tag)}"
+    headers = {"Accept": "application/vnd.github+json"}
+    if token := os.environ.get("GH_TOKEN"):
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        with urllib.request.urlopen(
+            urllib.request.Request(url, headers=headers)
+        ) as response:
+            return json.load(response)["body"]
+    except urllib.error.HTTPError as error:
+        raise RuntimeError(
+            f"Could not fetch Capture SDK release {tag}: {error}"
+        ) from error
+
+
+def extract_items(release_body: str, section: str, category: str) -> list[str]:
+    """Extract the category's bullets from one platform section.
+
+    The release in capture-sdk is organized as platform headings followed by
+    category headings. This method extracts the contentt from the bullets included
+    in each category inside each section.
+    """
+    current_section = ""
+    current_category = ""
+    items = []
+    blank_lines = []
+
+    for line in release_body.splitlines():
+        if line.startswith("### "):
+            # A new platform section also ends the preceding category
+            current_section = line.removeprefix("### ").strip()
+            current_category = ""
+            blank_lines = []
+        elif match := CATEGORY_HEADER.fullmatch(line):
+            # This accepts headings in case there's a formatting failure
+            current_category = match.group(1)
+            blank_lines = []
+        elif (
+            current_section == section
+            and current_category == category
+            and line.startswith("- ")
+        ):
+            items.append(line)
+            blank_lines = []
+        elif current_section == section and current_category == category and not line:
+            blank_lines.append(line)
+        elif (
+            current_section == section
+            and current_category == category
+            and items
+            and line[:1].isspace()
+        ):
+            # Markdown treats indented text as a continuation of the last item
+            items[-1] += "\n" + "\n".join(blank_lines + [line])
+            blank_lines = []
+        else:
+            blank_lines = []
+
+    return items
+
+
+def generate_notes(release_body: str) -> str:
+    """Render iOS and shared release notes, or the no-changes fallback"""
+    if not any(line.startswith("### ") for line in release_body.splitlines()):
+        raise RuntimeError(
+            "Capture SDK release notes do not contain any platform sections."
+        )
+
+    rendered_categories = []
+    for category in CATEGORIES:
+        items = extract_items(release_body, "iOS", category)
+        items.extend(extract_items(release_body, "Both", category))
+        if items:
+            rendered_categories.append(f"**{category}**\n\n" + "\n".join(items))
+
+    if not rendered_categories:
+        return "No customer-facing changes in this Capture iOS release.\n"
+
+    return "\n\n".join(rendered_categories) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "version", help="Capture SDK version, with or without a v prefix"
+    )
+    parser.add_argument("output_file", type=Path)
+    arguments = parser.parse_args()
+
+    arguments.output_file.write_text(
+        generate_notes(fetch_release_body(arguments.version))
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Overview
This PR adds a step on the release pipeline to copy the iOS related additions/changes/fixes that were included in the release of capture-sdk.
