### PR TITLE
Fixed the parsing of the version to remove double quotes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,8 @@ jobs:
         run: |
           if ! git diff --exit-code HEAD~1 HEAD .version; then
             echo "Detected changes..."
-            echo "version=\"$(cat .version)\"" >> $GITHUB_OUTPUT
+            version="$(tr -d '\r\n' < .version)"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
             echo "version_changed=true" >> $GITHUB_OUTPUT
           fi
   # This effectively releases a new Swift Package Manager version


### PR DESCRIPTION
# Overview
The generate release notes step parsed in a wrong format the version number (`"0.23.12"` instead of `0.23.12`) when trying to get the release notes from `capture-sdk`. This pr addressed this.

For more info, [here's GA run](https://github.com/bitdriftlabs/capture-ios/actions/runs/32419613084/job/96595955017) (it was made to fail silently as this shouldnt block the release for now). TL;DR:
> RuntimeError: Could not fetch Capture SDK release v"0.23.12": HTTP Error 404: Not Found
