### PR TITLE
Support multiple xcframeworks and xcodes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,3 +17,27 @@ jobs:
         run: ./tools/ci/mac_ci_setup.sh
       - name: Run Tests
         run: make test
+
+  manifest:
+    name: Manifest (Xcode ${{ matrix.xcode }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            xcode: '26.0.1'
+            artifact: Capture.zip
+          - runner: xcode-27
+            xcode: '27.0'
+            artifact: Capture.zip
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check that both manifests declare the same package
+        run: ./tools/ci/check_manifests_match.sh
+      - name: Set up CI
+        run: ./tools/ci/mac_ci_setup.sh ${{ matrix.xcode }}
+      - name: Check the resolved artifact
+        run: ./tools/ci/check_resolved_artifact.sh ${{ matrix.artifact }}
+      - name: Build against the resolved artifact
+        run: xcodebuild -scheme Capture-Package -destination 'generic/platform=iOS' build

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.4
+// swift-tools-version:6.0.0
 import PackageDescription
 
 let package = Package(

--- a/tools/ci/check_manifests_match.sh
+++ b/tools/ci/check_manifests_match.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly manifests=("Package.swift" "Package@swift-6.0.swift")
+
+function normalize() {
+  sed -e '1d' \
+    -e 's#\(url: "https://dl.bitdrift.io/sdk/ios/\).*#\1ARTIFACT",#' \
+    -e 's#\(checksum: "\)[^"]*\("\)#\1CHECKSUM\2#' \
+    "$1"
+}
+
+if diff <(normalize "${manifests[0]}") <(normalize "${manifests[1]}"); then
+  echo "+ ${manifests[0]} and ${manifests[1]} declare the same package"
+  exit 0
+fi
+
+echo "${manifests[0]} and ${manifests[1]} drifted apart, see the diff above" >&2
+exit 1

--- a/tools/ci/check_resolved_artifact.sh
+++ b/tools/ci/check_resolved_artifact.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly expected="$1"
+
+resolved="$(xcrun swift package dump-package |
+  grep -o 'https://dl\.bitdrift\.io/sdk/ios/capture-[^"]*' | head -1)"
+readonly resolved
+
+swift_version="$(xcrun swift --version 2>/dev/null |
+  sed -n 's/.*Apple Swift version \([0-9.]*\).*/\1/p' | head -1)"
+readonly swift_version
+
+if [[ -z "$resolved" ]]; then
+  echo "no Capture artifact URL found in the resolved manifest" >&2
+  exit 1
+fi
+
+if [[ "$resolved" != */"$expected" ]]; then
+  echo "Swift $swift_version resolved $resolved, expected the manifest pointing at $expected" >&2
+  exit 1
+fi
+
+echo "+ Swift $swift_version resolved $resolved"

--- a/tools/ci/mac_ci_setup.sh
+++ b/tools/ci/mac_ci_setup.sh
@@ -2,5 +2,14 @@
 
 set -euxo pipefail
 
+readonly xcode_version="${1:-26.0.1}"
+readonly xcode_app="/Applications/Xcode_$xcode_version.app"
+
 # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md#xcode
-sudo xcode-select --switch /Applications/Xcode_26.0.1.app
+if [[ ! -d "$xcode_app" ]]; then
+  echo "$xcode_app is not installed on this machine. Available Xcode versions:" >&2
+  ls -d /Applications/Xcode*.app >&2
+  exit 1
+fi
+
+sudo xcode-select --switch "$xcode_app"

--- a/tools/ci/swift_pm_package_update.sh
+++ b/tools/ci/swift_pm_package_update.sh
@@ -3,15 +3,29 @@
 set -euxo pipefail
 
 readonly version="$1"
-checksum="$(curl "https://dl.bitdrift.io/sdk/ios/capture-$version/Capture.zip.sha256")"
-readonly checksum=$checksum
+readonly base_url="https://dl.bitdrift.io/sdk/ios"
 
-# Look for a string in 'Package.swift' that looks like `capture-[VERSION]/Capture.zip` and substitute
-# existig version for the new one.
-sed -e "s#\(capture-\)\(.*\)\(/Capture\.zip\)#\1$version\3#g" Package.swift \
-  | sed -e "s#\(checksum: \"\)\(.*\)\(\"\)#\1$checksum\3#g" \
-  > Package_tmp.swift
-mv Package_tmp.swift Package.swift
+function update_manifest() {
+  local -r manifest="$1"
 
-echo "+ Generated Package.swift:"
-cat Package.swift
+  local artifact
+  artifact="$(sed -n "s#.*$base_url/capture-[^/]*/\([^\"]*\.zip\)\".*#\1#p" "$manifest" | head -1)"
+
+  if [[ -z "$artifact" ]]; then
+    echo "could not find a Capture artifact URL in $manifest" >&2
+    exit 1
+  fi
+
+  local checksum
+  checksum="$(curl -fsS "$base_url/capture-$version/$artifact.sha256")"
+
+  sed -e "s#\($base_url/capture-\)[^/]*\(/\)#\1$version\2#g" \
+    -e "s#\(checksum: \"\)[^\"]*\(\"\)#\1$checksum\2#g" \
+    "$manifest" > "$manifest.tmp"
+  mv "$manifest.tmp" "$manifest"
+
+  echo "+ Updated $manifest to $artifact $version"
+}
+
+update_manifest "Package.swift"
+update_manifest "Package@swift-6.0.swift"


### PR DESCRIPTION
# Overview
This PR adds swift-specific package manifests so customers using SPM automatically receive the `Capture.xcframework` compatible with their Xcode/Swift toolchain. This includes:
- Updates `Package.swift` to use swift tools `6.4` for the Xcode 27 distribution
- Created a `Package@swift-6.0.swift` to continue supporting Xcode 26
- Updates the release pipeline to handle the new complexity

This change is related to [this CI changes in `capture-sdk`](https://github.com/bitdriftlabs/capture-sdk/pull/1151)

> [!IMPORTANT]
> Once a new version is generated, we'll need to update the files that validates the manifests
